### PR TITLE
jma_collect()での平年値の取得

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # jmastats (development version)
 
+## New features
+
+* Retrieve climatological normals based on past data using `jma_collect()` (#20).
+
 ## Datasets 
 
 * Earth quake station dataset handled by the package have been updated to the latest version in September 2024.

--- a/R/jma_collect.R
+++ b/R/jma_collect.R
@@ -38,6 +38,7 @@
 #' - rank: Values of the largest in the history of observations.
 #' - nml_ym: Climatological normals for each year and month.
 #' - nml_3m: Climatological normals for each 3 months.
+#' - nml_10d: Climatological normals for each season (almost 10 days).
 #' for each location.
 #' @examples
 #' \donttest{
@@ -170,15 +171,24 @@ jma_collect_raw <- function(item = NULL, block_no, year, month, day, quiet) {
                                                     collapse = intToUtf8(c(12363L, 12425L))),
                     rank = stringr::str_extract(rank, "[0-9]{1,}")) |>
       readr::type_convert()
-  } else if (item %in% c("nml_ym", "nml_3m")) {
-    nml_meta <-
-      list(years = df[[2]][df[[2]] |>
-                             stringr::str_which(intToUtf8(65374))],
-           records = df[[2]][df[[2]] |>
-                               stringr::str_which(intToUtf8(65374))+1])
+  } else if (item %in% c("nml_ym", "nml_3m", "nml_10d")) {
+    if (item %in% c("nml_ym", "nml_3m")) {
+      nml_meta <-
+        list(years = df[[2]][df[[2]] |>
+                               stringr::str_which(intToUtf8(65374))],
+             records = df[[2]][df[[2]] |>
+                                 stringr::str_which(intToUtf8(65374))+1])
+    } else if (item %in% c("nml_10d")) {
+      nml_meta <-
+        list(years = df[[3]][df[[3]] |>
+                               stringr::str_which(intToUtf8(65374))],
+             records = df[[3]][df[[3]] |>
+                                 stringr::str_which(intToUtf8(65374))+1])
+    }
     nml_meta$years <-
       nml_meta$years |>
-      stringr::str_split(intToUtf8(65374), simplify = TRUE)
+      stringr::str_split(intToUtf8(65374), simplify = TRUE) |>
+      stringr::str_squish()
     cat(
       cli::col_br_blue(
         paste("\nThe record is based on the statistical period from",
@@ -809,7 +819,25 @@ name_sets <- function(item) {
                             "geq_35.0"),
                           "(\u2103)"),
                    jma_vars$daylight,
-                   jma_vars$snow[c(1, 3)])
+                   jma_vars$snow[c(1, 3)]),
+    "nml_10d_s" = c("elements",
+                    "elements2",
+                    jma_vars$atmosphere[2],
+                    stringr::str_remove(jma_vars$precipitation[1], "_sum"),
+                    jma_vars$temperature[c(1, 4, 5)],
+                    paste0("relative_humidity", "(%)"),
+                    jma_vars$wind[1],
+                    jma_vars$daylight,
+                    jma_vars$solar,
+                    jma_vars$snow[c(1, 3)],
+                    stringr::str_remove(jma_vars$cloud, "_mean")),
+    "nml_10d_a" = c("elements",
+                    "elements2",
+                    stringr::str_remove(jma_vars$precipitation[1], "_sum"),
+                    jma_vars$temperature[c(1, 4, 5)],
+                    jma_vars$wind[1],
+                    jma_vars$daylight,
+                    jma_vars$snow[c(1, 3)]),
     )
 }
 

--- a/R/jma_collect.R
+++ b/R/jma_collect.R
@@ -39,6 +39,7 @@
 #' - nml_ym: Climatological normals for each year and month.
 #' - nml_3m: Climatological normals for each 3 months.
 #' - nml_10d: Climatological normals for each season (almost 10 days).
+#' - nml_mb5d: Climatological normals for each semi-season (almost 5 days).
 #' for each location.
 #' @examples
 #' \donttest{
@@ -171,18 +172,24 @@ jma_collect_raw <- function(item = NULL, block_no, year, month, day, quiet) {
                                                     collapse = intToUtf8(c(12363L, 12425L))),
                     rank = stringr::str_extract(rank, "[0-9]{1,}")) |>
       readr::type_convert()
-  } else if (item %in% c("nml_ym", "nml_3m", "nml_10d")) {
+  } else if (item %in% c("nml_ym", "nml_3m", "nml_10d", "nml_mb5d")) {
     if (item %in% c("nml_ym", "nml_3m")) {
       nml_meta <-
         list(years = df[[2]][df[[2]] |>
                                stringr::str_which(intToUtf8(65374))],
              records = df[[2]][df[[2]] |>
                                  stringr::str_which(intToUtf8(65374))+1])
-    } else if (item %in% c("nml_10d")) {
+    } else if (item == "nml_10d") {
       nml_meta <-
         list(years = df[[3]][df[[3]] |>
                                stringr::str_which(intToUtf8(65374))],
              records = df[[3]][df[[3]] |>
+                                 stringr::str_which(intToUtf8(65374))+1])
+    } else if (item == "nml_mb5d") {
+      nml_meta <-
+        list(years = df[[4]][df[[4]] |>
+                               stringr::str_which(intToUtf8(65374))],
+             records = df[[4]][df[[4]] |>
                                  stringr::str_which(intToUtf8(65374))+1])
     }
     nml_meta$years <-
@@ -838,6 +845,17 @@ name_sets <- function(item) {
                     jma_vars$wind[1],
                     jma_vars$daylight,
                     jma_vars$snow[c(1, 3)]),
+    "nml_mb5d_s" = c(paste0("elements",
+                            c("", 2, 3)),
+                     stringr::str_remove(jma_vars$precipitation[1], "_sum"),
+                     jma_vars$temperature[c(1, 4, 5)],
+                     jma_vars$daylight,
+                     jma_vars$solar),
+    "nml_mb5d_a" = c(paste0("elements",
+                            c("", 2, 3)),
+                     stringr::str_remove(jma_vars$precipitation[1], "_sum"),
+                     jma_vars$temperature[c(1, 4, 5)],
+                     jma_vars$daylight)
     )
 }
 

--- a/man/jma_collect.Rd
+++ b/man/jma_collect.Rd
@@ -60,6 +60,10 @@ The parameter \code{item} chooses one from these:
 \item hourly: Hourly value. Please specify location, year, month and day.
 \item rank: Values of the largest in the history of observations.
 \item nml_ym: Climatological normals for each year and month.
+\item nml_3m: Climatological normals for each 3 months.
+\item nml_10d: Climatological normals for each season (almost 10 days).
+\item nml_mb5d: Climatological normals for each semi-season (almost 5 days).
+\item nml_daily: Daily climatological normals for specific month.
 for each location.
 }
 }
@@ -75,4 +79,6 @@ jma_collect("hourly", "0010", 2018, 7, 30, cache = FALSE)
 # Historical Ranking
 jma_collect("rank", block_no = "47646", year = 2020, cache = FALSE)
 }
+# Climatological normals
+jma_collect("nml_ym", block_no = "47646", cache = FALSE, pack = FALSE)
 }

--- a/man/jma_collect.Rd
+++ b/man/jma_collect.Rd
@@ -78,7 +78,10 @@ jma_collect(item = "daily", "0422", year = 2017, month = 11, cache = FALSE)
 jma_collect("hourly", "0010", 2018, 7, 30, cache = FALSE)
 # Historical Ranking
 jma_collect("rank", block_no = "47646", year = 2020, cache = FALSE)
-}
 # Climatological normals
 jma_collect("nml_ym", block_no = "47646", cache = FALSE, pack = FALSE)
+jma_collect("nml_3m", "47646", cache = FALSE, pack = FALSE, quiet = TRUE)
+jma_collect("nml_10d", "0228", cache = FALSE, pack = FALSE, quiet = TRUE)
+jma_collect("nml_mb5d", "0228", cache = FALSE, pack = FALSE, quiet = FALSE)
+}
 }

--- a/man/jma_collect.Rd
+++ b/man/jma_collect.Rd
@@ -58,7 +58,8 @@ The parameter \code{item} chooses one from these:
 \item mb5daily: Semi-seasonal value. Please specify location and year.
 \item daily: Daily value. Please specify location, year and month.
 \item hourly: Hourly value. Please specify location, year, month and day.
-\item rank: Values of the largest in the history of observations
+\item rank: Values of the largest in the history of observations.
+\item nml_ym: Climatological normals for each year and month.
 for each location.
 }
 }

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -20,7 +20,7 @@ test_that("input arguments validation", {
   )
 })
 
-test_that("multiplication works", {
+test_that("urls", {
   x <-
     jma_url(item = "daily",
             block_no = "0422",
@@ -44,6 +44,20 @@ test_that("multiplication works", {
     list(
       url = "https://www.data.jma.go.jp/stats/etrn/view/annually_a.php?prec_no=12&block_no=0010&year=2017&month=12&day=&view=", # nolint
       station_type = "a")
+  )
+  x <-
+    jma_url("nml_ym",
+            "47895")
+  expect_equal(
+    x[[1]],
+    "https://www.data.jma.go.jp/stats/etrn/view/nml_sfc_ym.php?prec_no=71&block_no=47895&year=&month=&view="
+  )
+  x <-
+    jma_url("nml_10d",
+            "1555")
+  expect_equal(
+    x[[1]],
+    "https://www.data.jma.go.jp/stats/etrn/view/nml_amd_10d.php?prec_no=51&block_no=1555&year=&month=&view="
   )
 })
 


### PR DESCRIPTION
## Summary

「過去の気象データ検索」から、平年値を取得する処理を追加しました。`jma_collect(item = )`に下記の引数を指定して実行します。

- `nml_ym`: 年・月ごとの平年値
- `nml_3m`: ３か月ごとの平年値
- `nml_10d`: 旬ごとの平年値
- `nml_mb5d`: 半旬ごとの平年値
- `nml_daily`: 月の日ごとの平年値。このitemを指定する際は、対象のmonthの指定も必要です。

``` r
library(jmastats)
#> ℹ Loading jmastats
jma_collect("nml_10d", "0228", pack = FALSE)
#> Data from: https://www.data.jma.go.jp/stats/etrn/view/nml_amd_10d.php?prec_no=33&block_no=0228&year=&month=&view=
#> The record is based on the statistical period from 1991 to 2020 (30 years of data).
#> Treated as missing: lines 1, 2, 3, 4, 5, 6, 36 at temperature_average(℃)
#> Treated as missing: lines 1, 2, 3, 4, 5, 6, 7, 8, 9, 33, 34, 35, 36 at temperature_min(℃)
#> Treated as missing: lines 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36 at snow_fall(cm)
#> Treated as missing: lines 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36 at snow_depth(cm)
#> 
#> ── Column specification ────────────────────────────────────────────────────────
#> cols(
#>   element = col_character(),
#>   element2 = col_character(),
#>   `precipitation(mm)` = col_double(),
#>   `temperature_average(℃)` = col_double(),
#>   `temperature_max(℃)` = col_double(),
#>   `temperature_min(℃)` = col_double(),
#>   `wind_average_speed(m/s)` = col_double(),
#>   `daylight_(h)` = col_double(),
#>   `snow_fall(cm)` = col_logical(),
#>   `snow_depth(cm)` = col_logical()
#> )
#> # A tibble: 36 × 9
#>    element `precipitation(mm)` `temperature_average(℃)` `temperature_max(℃)`
#>    <chr>                 <dbl>                    <dbl>                <dbl>
#>  1 1月上旬                19.4                     -1.5                  2.5
#>  2 1月中旬                12.3                     -2.4                  1.9
#>  3 1月下旬                14.8                     -2.3                  2  
#>  4 2月上旬                12                       -2.1                  2.3
#>  5 2月中旬                16.7                     -1.4                  3.1
#>  6 2月下旬                11.1                     -0.3                  4.7
#>  7 3月上旬                26.9                      0.8                  5.7
#>  8 3月中旬                22.5                      2.3                  7.8
#>  9 3月下旬                27.6                      3.7                  9.5
#> 10 4月上旬                24.2                      6.3                 12.3
#> # ℹ 26 more rows
#> # ℹ 5 more variables: `temperature_min(℃)` <dbl>,
#> #   `wind_average_speed(m/s)` <dbl>, `daylight_(h)` <dbl>,
#> #   `snow_fall(cm)` <lgl>, `snow_depth(cm)` <lgl>
```

<sup>Created on 2024-09-11 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

## Relate issues

Close #20