### PR TITLE
fix(collect): create cache directory before saving

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # jmastats (development version)
 
+## Fixes
+
+* `jma_collect(cache = TRUE)` no longer fails when the cache directory does not exist, such as on a fresh install or after `reset_cache()` (#26).
+
 # jmastats 0.3.0
 
 ## New features

--- a/R/appdir.R
+++ b/R/appdir.R
@@ -44,3 +44,10 @@ search_cache_file <- function(item, station_type, param) {
     )
   )
 }
+
+ensure_cache_dir <- function(path) {
+  if (!dir.exists(path)) {
+    dir.create(path, recursive = TRUE, showWarnings = FALSE)
+  }
+  invisible(path)
+}

--- a/R/jma_collect.R
+++ b/R/jma_collect.R
@@ -83,6 +83,7 @@ jma_collect <- function(
     } else {
       out <-
         slow_jma_collect(item, block_no, year, month, day, quiet)
+      ensure_cache_dir(dirname(file_loc))
       saveRDS(out, file = file_loc)
     }
   } else {

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -76,3 +76,14 @@ test_that("Set coords", {
     )
   )
 })
+
+test_that("cache directory is created on demand", {
+  root <- tempfile()
+  on.exit(unlink(root, recursive = TRUE), add = TRUE)
+  path <- file.path(root, "jmastats", "nested")
+  expect_false(dir.exists(path))
+  expect_equal(ensure_cache_dir(path), path)
+  expect_true(dir.exists(path))
+  expect_silent(ensure_cache_dir(path))
+  expect_true(dir.exists(path))
+})


### PR DESCRIPTION
`jma_collect(cache = TRUE)` failed whenever the cache directory did not exist. `search_cache_file()` only composes a path with `rappdirs::user_cache_dir("jmastats")`, so `saveRDS()` on the cache-miss branch hit a missing directory. `reset_cache()` removes the directory recursively and nothing recreated it, so a fresh install, a container/CI run, or a single `reset_cache()` call broke caching permanently.

## Changes

- `R/appdir.R`: add `ensure_cache_dir()` — `dir.create(recursive = TRUE, showWarnings = FALSE)` when the path is missing. `search_cache_file()` stays the single source of the cache path and stays free of side effects; `reset_cache()` and `pick_out_cache()` are untouched (`unlink()` on a missing path is already a no-op).
- `R/jma_collect.R`: call `ensure_cache_dir(dirname(file_loc))` on the cache-miss branch, immediately before `saveRDS()`.
- `tests/testthat/test-internals.R`: cover directory creation and idempotency under `tempfile()`. The test never touches the real cache directory and stays offline.
- `NEWS.md`: entry under the development version.

## Verification

- `devtools::test()`: `FAIL 0 | WARN 0 | SKIP 2 | PASS 43` (baseline 38 passed; the 2 skips are the existing `{lwgeom}` ones)
- `air format R tests --check`: pass

Closes #26